### PR TITLE
add rules for USB on Raspi 4

### DIFF
--- a/udev/freetserv.rules
+++ b/udev/freetserv.rules
@@ -18,71 +18,131 @@ ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].1:1.0", SYMLINK+="free
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].1:1.1", SYMLINK+="freetserv/port3", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].1:1.2", SYMLINK+="freetserv/port2", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].1:1.3", SYMLINK+="freetserv/port1", MODE="600", OWNER="nobody"
+# First PCB, FTDI1 on Raspi 4
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].1:1.0", SYMLINK+="freetserv/port4", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].1:1.1", SYMLINK+="freetserv/port3", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].1:1.2", SYMLINK+="freetserv/port2", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].1:1.3", SYMLINK+="freetserv/port1", MODE="600", OWNER="nobody"
 
 # First PCB, FTDI2
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].2:1.0", SYMLINK+="freetserv/port8", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].2:1.1", SYMLINK+="freetserv/port7", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].2:1.2", SYMLINK+="freetserv/port6", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].2:1.3", SYMLINK+="freetserv/port5", MODE="600", OWNER="nobody"
+# First PCB, FTDI2 on Raspi 4
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].2:1.0", SYMLINK+="freetserv/port8", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].2:1.1", SYMLINK+="freetserv/port7", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].2:1.2", SYMLINK+="freetserv/port6", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].2:1.3", SYMLINK+="freetserv/port5", MODE="600", OWNER="nobody"
 
 # First PCB, FTDI3
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].3:1.0", SYMLINK+="freetserv/port12", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].3:1.1", SYMLINK+="freetserv/port11", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].3:1.2", SYMLINK+="freetserv/port10", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].3:1.3", SYMLINK+="freetserv/port9", MODE="600", OWNER="nobody"
+# First PCB, FTDI3 on Raspi 4
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].3:1.0", SYMLINK+="freetserv/port12", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].3:1.1", SYMLINK+="freetserv/port11", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].3:1.2", SYMLINK+="freetserv/port10", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].3:1.3", SYMLINK+="freetserv/port9", MODE="600", OWNER="nobody"
 
 # Second PCB, FTDI1
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.1:1.0", SYMLINK+="freetserv/port16", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.1:1.1", SYMLINK+="freetserv/port15", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.1:1.2", SYMLINK+="freetserv/port14", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.1:1.3", SYMLINK+="freetserv/port13", MODE="600", OWNER="nobody"
+# Second PCB, FTDI1 on Raspi 4
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.1:1.0", SYMLINK+="freetserv/port16", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.1:1.1", SYMLINK+="freetserv/port15", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.1:1.2", SYMLINK+="freetserv/port14", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.1:1.3", SYMLINK+="freetserv/port13", MODE="600", OWNER="nobody"
 
 # Second PCB, FTDI2
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.2:1.0", SYMLINK+="freetserv/port20", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.2:1.1", SYMLINK+="freetserv/port19", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.2:1.2", SYMLINK+="freetserv/port18", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.2:1.3", SYMLINK+="freetserv/port17", MODE="600", OWNER="nobody"
+# Second PCB, FTDI2 on Raspi 4
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.2:1.0", SYMLINK+="freetserv/port20", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.2:1.1", SYMLINK+="freetserv/port19", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.2:1.2", SYMLINK+="freetserv/port18", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.2:1.3", SYMLINK+="freetserv/port17", MODE="600", OWNER="nobody"
 
 # Second PCB, FTDI3
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.3:1.0", SYMLINK+="freetserv/port24", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.3:1.1", SYMLINK+="freetserv/port23", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.3:1.2", SYMLINK+="freetserv/port22", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.3:1.3", SYMLINK+="freetserv/port21", MODE="600", OWNER="nobody"
+# Second PCB, FTDI3 on Raspi 4
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.3:1.0", SYMLINK+="freetserv/port24", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.3:1.1", SYMLINK+="freetserv/port23", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.3:1.2", SYMLINK+="freetserv/port22", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.3:1.3", SYMLINK+="freetserv/port21", MODE="600", OWNER="nobody"
 
 # Third PCB, FTDI1
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.1:1.0", SYMLINK+="freetserv/port28", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.1:1.1", SYMLINK+="freetserv/port27", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.1:1.2", SYMLINK+="freetserv/port26", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.1:1.3", SYMLINK+="freetserv/port25", MODE="600", OWNER="nobody"
+# Third PCB, FTDI1 on Raspi 4
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.1:1.0", SYMLINK+="freetserv/port28", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.1:1.1", SYMLINK+="freetserv/port27", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.1:1.2", SYMLINK+="freetserv/port26", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.1:1.3", SYMLINK+="freetserv/port25", MODE="600", OWNER="nobody"
 
 # Third PCB, FTDI2
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.2:1.0", SYMLINK+="freetserv/port32", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.2:1.1", SYMLINK+="freetserv/port31", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.2:1.2", SYMLINK+="freetserv/port30", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.2:1.3", SYMLINK+="freetserv/port29", MODE="600", OWNER="nobody"
+# Third PCB, FTDI2 on Raspi 4
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.2:1.0", SYMLINK+="freetserv/port32", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.2:1.1", SYMLINK+="freetserv/port31", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.2:1.2", SYMLINK+="freetserv/port30", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.2:1.3", SYMLINK+="freetserv/port29", MODE="600", OWNER="nobody"
 
 # Third PCB, FTDI3
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.3:1.0", SYMLINK+="freetserv/port36", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.3:1.1", SYMLINK+="freetserv/port35", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.3:1.2", SYMLINK+="freetserv/port34", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.3:1.3", SYMLINK+="freetserv/port33", MODE="600", OWNER="nobody"
+# Third PCB, FTDI3 on Raspi 4
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.3:1.0", SYMLINK+="freetserv/port36", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.3:1.1", SYMLINK+="freetserv/port35", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.3:1.2", SYMLINK+="freetserv/port34", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.3:1.3", SYMLINK+="freetserv/port33", MODE="600", OWNER="nobody"
 
 # Fourth PCB, FTDI1
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.4.1:1.0", SYMLINK+="freetserv/port40", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.4.1:1.1", SYMLINK+="freetserv/port39", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.4.1:1.2", SYMLINK+="freetserv/port38", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.4.1:1.3", SYMLINK+="freetserv/port37", MODE="600", OWNER="nobody"
+# Fourth PCB, FTDI1 on Raspi 4
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.4.1:1.0", SYMLINK+="freetserv/port40", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.4.1:1.1", SYMLINK+="freetserv/port39", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.4.1:1.2", SYMLINK+="freetserv/port38", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.4.1:1.3", SYMLINK+="freetserv/port37", MODE="600", OWNER="nobody"
 
 # Fourth PCB, FTDI2
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.4.2:1.0", SYMLINK+="freetserv/port44", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.4.2:1.1", SYMLINK+="freetserv/port43", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.4.2:1.2", SYMLINK+="freetserv/port42", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.4.2:1.3", SYMLINK+="freetserv/port41", MODE="600", OWNER="nobody"
+# Fourth PCB, FTDI2 on Raspi 4
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.4.2:1.0", SYMLINK+="freetserv/port44", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.4.2:1.1", SYMLINK+="freetserv/port43", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.4.2:1.2", SYMLINK+="freetserv/port42", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.4.2:1.3", SYMLINK+="freetserv/port41", MODE="600", OWNER="nobody"
 
 # Fourth PCB, FTDI3
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.4.3:1.0", SYMLINK+="freetserv/port48", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.4.3:1.1", SYMLINK+="freetserv/port47", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.4.3:1.2", SYMLINK+="freetserv/port46", MODE="600", OWNER="nobody"
 ENV{ID_PATH}=="platform-bcm2708_usb-usb-[0-9]:[0-9].[0-9].4.4.4.3:1.3", SYMLINK+="freetserv/port45", MODE="600", OWNER="nobody"
+# Fourth PCB, FTDI3 on Raspi 4
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.4.3:1.0", SYMLINK+="freetserv/port48", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.4.3:1.1", SYMLINK+="freetserv/port47", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.4.3:1.2", SYMLINK+="freetserv/port46", MODE="600", OWNER="nobody"
+ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9]:[0-9].[0-9].4.4.4.3:1.3", SYMLINK+="freetserv/port45", MODE="600", OWNER="nobody"
 
 LABEL="freetserv_end"


### PR DESCRIPTION
Raspi 4 has platform-fd500000.pcie-pci-0000:01:00.0-usb-[0-9] instead of platform-bcm2708_usb-usb-[0-9].
Having rules for Raspi 2 and 4 create (and remove) the same symlinks should be fine as only one of the rules matches and as long as there is a match, the symlink gets created.